### PR TITLE
Re-export Attributes from Ecsy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Schema, ArraySchema, type, MapSchema } from "@colyseus/schema";
 
 import {
+    Attributes,
     World as EcsyWorld,
     WorldOptions,
     _Entity as EcsyEntity,
@@ -197,4 +198,4 @@ export class World extends EcsyWorld {
     }
 }
 
-export { System };
+export { Attributes, System };


### PR DESCRIPTION
This PR allows custom systems to be built in packages importing `@colyseus/ecs` with properly defined types.

For instance it allows the following to be written without TS errors or falling back to any/unknown types:

```ts
import { Attributes, System, World } from '@colyseus/ecs'

export class MySystem extends System {
  constructor(private injectedDependency: MyInjectedDependency, world: World, attributes?: Attributes) {
    super(...)
  }
}
```
