### PR TITLE
Force getMutableComponent onChange

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,8 @@ export class World extends EcsyWorld {
                 entityManager._queryManager.onEntityComponentAdded(entity, ComponentType);
                 componentsManager.componentAddedToEntity(ComponentType);
 
+                component.onChange = () => { entity.getMutableComponent(ComponentType as any) }
+
                 // TODO: improve me.
                 entityManager.eventDispatcher.dispatchEvent('EntityManager#COMPONENT_ADDED', entity, ComponentType);
             }


### PR DESCRIPTION
I'm not sure if this is the best approach, but it works when I manually make the change in my local `colyseus/ecs` files in `node_modules`

Currently changes to components do not appear in the `changed` arrays in System `queries` . This is because these changes are registered when systems call `Entity.getMutableComponent`, however the schema directly decodes the changes into the component bypassing this call.

This adds an `onChange` handler in `enableAutoDecoding` which calls `getMutableComponent` when a component is changed.

P.S. my editor *really* wants to use a different code style so sorry if it doesn't match your existing styles!