### PR TITLE
Fix for errors when removing entities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,14 +89,23 @@ export class Entity extends Schema {
     }
     
     reset() {
+        // @ts-ignore
         this.id = this._entityManager._nextEntityId++;
 
+        // @ts-ignore
         for (var ecsyComponentId in this._ComponentTypes) {
+            // @ts-ignore
             delete this._components[ecsyComponentId];
         }
         
+        // @ts-ignore
         this._ComponentTypes.length = 0;
+        
+        // @ts-ignore
         this.queries.length = 0;
+        
+        // clear refId to ensure a new one is going to be assigned
+        this['$changes'].refId = undefined;
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,17 @@ export class Entity extends Schema {
         // @ts-ignore
         this.numStateComponents = 0;
     }
+    
+    reset() {
+        this.id = this._entityManager._nextEntityId++;
+
+        for (var ecsyComponentId in this._ComponentTypes) {
+            delete this._components[ecsyComponentId];
+        }
+        
+        this._ComponentTypes.length = 0;
+        this.queries.length = 0;
+    }
 }
 
 //


### PR DESCRIPTION
Override `entity.remove` to avoid removing all colyseus schema fields on resetting an entity.